### PR TITLE
Remove unused dependencies

### DIFF
--- a/spring-boot-agent/app/pom.xml
+++ b/spring-boot-agent/app/pom.xml
@@ -1,22 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>spring-boot-agent</artifactId>
-        <groupId>com.ctrip.framework.apollo</groupId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>app</artifactId>
-
-    <dependencies>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-    </dependencies>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">  
+    <parent> 
+        <artifactId>spring-boot-agent</artifactId>  
+        <groupId>com.ctrip.framework.apollo</groupId>  
+        <version>1.0-SNAPSHOT</version> 
+    </parent>  
+    <modelVersion>4.0.0</modelVersion>  
+    <artifactId>app</artifactId>  
+    <dependencies> 
+        <dependency> 
+            <groupId>org.springframework.boot</groupId>  
+            <artifactId>spring-boot-starter</artifactId>  
+            <exclusions> 
+                <exclusion> 
+                    <groupId>javax.annotation</groupId>  
+                    <artifactId>javax.annotation-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>org.springframework.boot</groupId>  
+                    <artifactId>spring-boot-starter-logging</artifactId> 
+                </exclusion> 
+            </exclusions> 
+        </dependency>  
+        <dependency> 
+            <groupId>com.ctrip.framework.apollo</groupId>  
+            <artifactId>apollo-client</artifactId>  
+            <version>1.5.0</version>  
+            <scope>compile</scope>  
+            <exclusions> 
+                <exclusion> 
+                    <groupId>javax.inject</groupId>  
+                    <artifactId>javax.inject</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>aopalliance</groupId>  
+                    <artifactId>aopalliance</artifactId> 
+                </exclusion> 
+            </exclusions> 
+        </dependency> 
+    </dependencies>  
+    <dependencyManagement> 
+        <dependencies> 
+            <dependency> 
+                <groupId>org.springframework.boot</groupId>  
+                <artifactId>spring-boot</artifactId>  
+                <version>2.0.3.RELEASE</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.springframework.boot</groupId>  
+                <artifactId>spring-boot-autoconfigure</artifactId>  
+                <version>2.0.3.RELEASE</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.springframework</groupId>  
+                <artifactId>spring-core</artifactId>  
+                <version>5.0.7.RELEASE</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>ch.qos.logback</groupId>  
+                <artifactId>logback-classic</artifactId>  
+                <version>1.2.3</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.apache.logging.log4j</groupId>  
+                <artifactId>log4j-to-slf4j</artifactId>  
+                <version>2.10.0</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.slf4j</groupId>  
+                <artifactId>jul-to-slf4j</artifactId>  
+                <version>1.7.25</version> 
+            </dependency> 
+        </dependencies> 
+    </dependencyManagement> 
 </project>


### PR DESCRIPTION
@nobodyiam Hi, I am a user of project **_com.ctrip.framework.apollo:app:1.0-SNAPSHOT_**. I found that its pom file introduced **_26_** dependencies. However, among them, **_9_** libraries (**_34%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.ctrip.framework.apollo:app:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.springframework.boot:spring-boot-starter-logging:jar:2.0.3.RELEASE:compile
aopalliance:aopalliance:jar:1.0:compile
ch.qos.logback:logback-core:jar:1.2.3:compile
ch.qos.logback:logback-classic:jar:1.2.3:compile
org.apache.logging.log4j:log4j-api:jar:2.10.0:compile
javax.annotation:javax.annotation-api:jar:1.3.2:compile
javax.inject:javax.inject:jar:1:compile
org.apache.logging.log4j:log4j-to-slf4j:jar:2.10.0:compile
org.slf4j:jul-to-slf4j:jar:1.7.25:compile
</code></pre>
